### PR TITLE
Update to the view method, and improvements to the header parsing and writing bits, officially there is a metadata block-end delimiter.

### DIFF
--- a/kmerdb/__init__.py
+++ b/kmerdb/__init__.py
@@ -405,8 +405,8 @@ def get_matrix(arguments):
     final_df.to_csv(sys.stdout, sep=arguments.output_delimiter, index=arguments.with_index)
     logger.info("Done printing {0} matrix to STDOUT".format(arguments.method))
 
-    logger.info("Beginning distribution analysis in R...")
-    logger.warn("Not implemented in Python...")
+    #logger.info("Beginning distribution analysis in R...")
+    #logger.warn("Not implemented in Python...")
     
     sys.stderr.write(config.DONE)
 
@@ -706,20 +706,71 @@ def header(arguments):
     
             
 def view(arguments):
-    from kmerdb import fileutil
-
-    from kmerdb.config import VERSION
-    if os.path.splitext(arguments.kdb)[-1] != ".kdb":
-        raise IOError("Viewable .kdb filepath does not end in '.kdb'")
-
-    with fileutil.open(arguments.kdb, mode='r') as kdb:
-        if kdb.header["version"] != VERSION:
-            logger.warning("KDB version is out of date, may be incompatible with current KDBReader class")
+    from kmerdb import fileutil, config
+    import json
+    header = None
+    if type(arguments.kdb_in) is not str: # Read from STDIN
+        logger.warning("Interpreting data from STDIN as uncompressed .kdb input")
+        header = ''
+        kdb_in = None
+        while type(header) is str:
+            line = sys.stdin.readline().rstrip()
+            if line != config.end_header_line:
+                header += line
+                continue
+            else:
+                header_dict = yaml.safe_parse(header)
+                if type(header_dict) is not dict:
+                    logger.debug("Tried to parse:\n{0}\n".format(header))
+                    raise ValueError("Could not parse YAML formatted header")
+                else:
+                    if header["version"] != config.VERSION:
+                        logger.warning("KDB version is out of date, may be incompatible with current KDBReader class")
+                    kdb_in = sys.stdin
+                    header=header_dict
+    else:
+        assert type(arguments.kdb_in) is str, "kdb_in must be a str"
+        if os.path.splitext(arguments.kdb_in)[-1] != ".kdb": # A filepath with invalid suffix
+            raise IOError("Viewable .kdb filepath does not end in '.kdb'")
+        elif not os.path.exists(arguments.kdb_in):
+            raise IOError("Viewable .kdb filepath '{0}' does not exist on the filesystem".format(arguments.kdb_in))
+        kdb_in = fileutil.open(arguments.kdb_in, mode='r')
+        header = kdb_in.header
+    if header["version"] != config.VERSION:
+        logger.warning("KDB version is out of date, may be incompatible with current KDBReader class")
+    if arguments.kdb_out is None or arguments.kdb_out == "/dev/stdout" or arguments.kdb_out == "STDOUT": # Write to stdout, uncompressed
         if arguments.header:
             print(yaml.dump(kdb.header))
-        for line in kdb:
+        for line in kdb_in:
             print(line.rstrip())
+    elif arguments.kdb_out is not None and arguments.compress: # Can't yet write compressed to stdout
+        logger.error("Can't write kdb to stdout! We need to use a Bio.bgzf filehandle.")
+        sys.exit(1)
+    elif type(arguments.kdb_out) is not str:
+        raise ValueError("Cannot write a file to an argument that isn't a string")
+    elif os.path.exists(arguments.kdb_out):
+        logger.warning("Overwriting '{0}'...".format(arguments.kdb_out))
+    elif not os.path.exists(arguments.kdb_out):
+        logger.debug("Creating '{0}'...".format(arguments.kdb_out))
+    with fileutil.open(arguments.kdb_out, header=header, mode='wb') as kdb_out:
+        try:
+            line = None
+            for line in kdb_in:
+                line = line.rstrip()
+                kmer_id, count, metadata = line.split("\t")
+                kmer_id, count = int(kmer_id), int(count)
+                kdb_out.write("{0}\t{1}\t{2}\n".format(kmer_id, count, json.dumps(metadata)))
+        except StopIteration as e:
+            logger.error(e)
+            raise e
+        finally:
+            #kdb_out._write_block(kdb_out._buffer)
+            #kdb_out._handle.flush()
+            #kdb_out._handle.close()
+            sys.stderr.write(config.DONE)
 
+
+            
 def profile(arguments):
     import math
     from kmerdb import parse, fileutil, kmer
@@ -751,8 +802,8 @@ def profile(arguments):
     header["metadata_blocks"] = math.ceil( sys.getsizeof(header_bytes) / ( 2**16 ) ) # Second estimate
     #header["metadata_blocks"] = 2
     logger.info("Collapsing the k-mer counts across the various input files into the final kdb file '{0}'".format(arguments.kdb))    
+    kdb_out = fileutil.open(arguments.kdb, 'wb', header)
     try:
-        kdb_out = fileutil.open(arguments.kdb, 'wb', header)
         iterating = True
         while iterating:
             try:
@@ -768,8 +819,8 @@ def profile(arguments):
                         pass
                     else:
                         seq = kmer.id_to_kmer(i, arguments.k)
-                        neighbors = kmer.neighbors(seq, arguments.k)
-                        kdb_out.write("{0}\t{1}\t{2}\n".format(i, count, json.dumps(neighbors)))
+                        metadata = kmer.neighbors(seq, arguments.k) # metadata is initialized by the neighbors
+                        kdb_out.write("{0}\t{1}\t{2}\n".format(i, count, json.dumps(metadata)))
                 else:
                     iterating = False
             except StopIteration as e:
@@ -890,7 +941,9 @@ def cli():
     view_parser = subparsers.add_parser("view", help="View the contents of the .kdb file")
     view_parser.add_argument("-v", "--verbose", help="Prints warnings to the console by default", default=0, action="count")
     view_parser.add_argument("-H", "--header", action="store_true", help="Include header in the output")
-    view_parser.add_argument("kdb", type=str, help="A k-mer database file (.kdb)")
+    view_parser.add_argument("-c", "--compress", action="store_true", help="Print compressed output")
+    view_parser.add_argument("kdb_in", type=str, nargs="?", default=None, help="A k-mer database file (.kdb) to be read (Optional)")
+    view_parser.add_argument("kdb_out", type=str, nargs="?", default=None, help="A k-mer database file (.kdb) to be written to (Optional)")
     view_parser.set_defaults(func=view)
 
 

--- a/kmerdb/__init__.py
+++ b/kmerdb/__init__.py
@@ -703,7 +703,7 @@ def header(arguments):
         else:
             yaml.add_representer(OrderedDict, util.represent_ordereddict)
             print(yaml.dump(kdb.header))
-    
+            print(config.header_delimiter)
             
 def view(arguments):
     from kmerdb import fileutil, config

--- a/kmerdb/config.py
+++ b/kmerdb/config.py
@@ -18,6 +18,8 @@
 
 
 VERSION="0.0.7"
+end_header_line = "    kdb: can someone get me some sentries"
+header_delimiter = end_header_line + "\n" + ("="*24) + "\n"
 
 header_schema = {
     "type": "object",


### PR DESCRIPTION
Closes issue #26.

