### PR TITLE
Graph db with offsets

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: python
 python:
+  - "3.6.4"
   - "3.7.4"
+  - "3.8.4"
 before_install:
   - sudo apt-get -y install r-base
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
 python:
-  - "3.6.4"
   - "3.7.4"
   - "3.8.4"
 before_install:

--- a/TODO.org
+++ b/TODO.org
@@ -4,9 +4,34 @@
 The initial prototype would be plaintext
 The final prototype would be .bgzf format from biopython
 
+* Outbox
+** DONE Sparse .kdb
+   CLOSED: [2021-01-07 Thu 21:37]
+*** modify slurp
+*** modify profile
+** DONE Nearest neighbor profile
+   CLOSED: [2021-01-07 Thu 21:37]
+** DONE index class
+   CLOSED: [2021-01-13 Wed 19:13]
+** DONE Probability function
+   CLOSED: [2021-01-13 Wed 19:13]
 
-
-
+** DONE kmerdb shuf
+   CLOSED: [2021-01-18 Mon 13:53]
+*** shuffled profiles
+*** Use kdb header
+*** Use shuf on lines printed to temporary file
+*** Hardcode the alternative method to readline:
+**** def KDBReader.readline():
+****     kmer_id, count, metadata = parse_line(self.readline())
+****     assert type(kmer_id) is int, "kmer_id wasn't an integer when passed in from parse_line"
+****     assert type(count) is int, "count wasn't an integer when passed in from parse_line"
+****     assert type(metadata) is dict, "metadata wasn't a dict when passed in from parse_line
+****     return kmer_id, count, metadata
+**** THEN DO THE ACTUAL HARDCODING OF THE ALTERNATIVE WHICH IS AS FOLLOWS
+**** use readline to parse the counts, the count is all you need, populate that into a list
+**** then convert that list into an nd.array and write it plus the index (enumerate) to disk
+**** like you would do in profile
 * Assessment of probability function
 ** sequence length, starting position, strand
 ** The length of the parameter space theta is 3
@@ -28,16 +53,38 @@ The final prototype would be .bgzf format from biopython
 ** and it would eventually produce the correct sequence through brute force.
 ** The brute force method is to try random walks with the same initialized k-mer.
 ** Then we do 
-* DONE Sparse .kdb
-  CLOSED: [2021-01-07 Thu 21:37]
-** modify slurp
-** modify profile
-* DONE Nearest neighbor profile
-  CLOSED: [2021-01-07 Thu 21:37]
-* DONE index class
-  CLOSED: [2021-01-13 Wed 19:13]
-* DONE Probability function
-  CLOSED: [2021-01-13 Wed 19:13]
+
+* VERIFY store fasta/fastq offsets in the database
+* Release 0.0.7
+* Do report 1:
+* Rmd report1
+** Introduction
+*** 
+** Methodology
+** Results
+*** Distribution fitting / model selection
+*** PCA
+*** kmerdb shuf on 3 of 30 metagenomes for k=1:12 + kPAL figure 
+*** Median "distance" between profiles of pairwise comparison
+** Distribution analysis
+** Accurately describe kdb counting algorithm
+*** althought the algorithm differs in its approach to fastq k-mer counting from fasta k-mer counting,
+*** First, a selection of sequences is shredded into k-mers in memory
+*** Second, the counts are tallied on-disk using SQLite3.
+*** Third, the SQLite3 database iterator is used to pull row from row out and print line by line into the kdb datastructure.
+*** Fourth, at this point, an index may be created.
+** Distribution fitting
+*** Cullen-Frey
+*** Negative binomial fit
+*** Poissonian imitation (average, geom. mean, median, mode) [each] vs negative binomial fit to the data
+** Count normalization
+*** Next, we want to judge the effect of DESeq2 normalization on the counts values.
+*** We use a boxplot to address the null-hypothesis that DESeq2 normalization does not meaningfully harmonize each samples quartiles with one another.
+*** We must check this often when addressing our normalized data because failure to normalize properly
+*** due to an issue that is not library size or total counts, 
+*** suggests another issue with the distribution of that sample.
+*** State why we refuse to standardize the data at this point.
+
 * TODO kmerdb transitions
 ** transition probabilities of the primary sequence
 ** [kmerdb.probability.transition(kdb, i, j) for i in range(N) for j in range(N)]
@@ -70,48 +117,7 @@ The final prototype would be .bgzf format from biopython
 ** assert suffix == ".kdb", "provided filename did not end in .kdb"
 ** shutil.move(fasta, prefix + ".fa")
 ** write kdb file (prefix + ".kdb")
-* TODO kmerdb shuf
-** shuffled profiles
-** Use kdb header
-** Use shuf on lines printed to temporary file
-** Hardcode the alternative method to readline:
-*** def KDBReader.readline():
-***     kmer_id, count, metadata = parse_line(self.readline())
-***     assert type(kmer_id) is int, "kmer_id wasn't an integer when passed in from parse_line"
-***     assert type(count) is int, "count wasn't an integer when passed in from parse_line"
-***     assert type(metadata) is dict, "metadata wasn't a dict when passed in from parse_line
-***     return kmer_id, count, metadata
-*** THEN DO THE ACTUAL HARDCODING OF THE ALTERNATIVE WHICH IS AS FOLLOWS
-*** use readline to parse the counts, the count is all you need, populate that into a list
-*** then convert that list into an nd.array and write it plus the index (enumerate) to disk
-*** like you would do in profile
-* Rmd report1
-** Introduction
-** Methodology
-** Results
-*** Distribution fitting / model selection
-*** PCA
-*** kmerdb shuf on 3 of 30 metagenomes for k=1:12 + kPAL figure 
-*** Median "distance" between profiles of pairwise comparison
-** Distribution analysis
-** Accurately describe kdb counting algorithm
-*** althought the algorithm differs in its approach to fastq k-mer counting from fasta k-mer counting,
-*** First, a selection of sequences is shredded into k-mers in memory
-*** Second, the counts are tallied on-disk using SQLite3.
-*** Third, the SQLite3 database iterator is used to pull row from row out and print line by line into the kdb datastructure.
-*** Fourth, at this point, an index may be created.
-** Distribution fitting
-*** Cullen-Frey
-*** Negative binomial fit
-*** Poissonian imitation (average, geom. mean, median, mode) [each] vs negative binomial fit to the data
-** Count normalization
-*** Next, we want to judge the effect of DESeq2 normalization on the counts values.
-*** We use a boxplot to address the null-hypothesis that DESeq2 normalization does not meaningfully harmonize each samples quartiles with one another.
-*** We must check this often when addressing our normalized data because failure to normalize properly
-*** due to an issue that is not library size or total counts, 
-*** suggests another issue with the distribution of that sample.
-*** State why we refuse to standardize the data at this point.
-
+* Do report 2
 * Rmd report2
 ** algorithm profiling
 ** kdb profile k x time x cpu (z)

--- a/examples/example_report/index.Rmd
+++ b/examples/example_report/index.Rmd
@@ -267,7 +267,7 @@ ggplot(data2) + geom_density(aes(x=Count)) + geom_line(data=d5, aes(y=Fit, x=x, 
 ```
 
 
-```{r fig.cap="" fig.width=8.41, fig.height=6.5, out.extra='angle=90', echo=FALSE, eval=FALSE}
+```{r fig.cap="VGLM is not working", fig.width=8.41, fig.height=6.5, out.extra='angle=90', echo=FALSE, eval=FALSE}
 
 data2$id <- rep(1:4^k, length(columns))
 d = data2[order(data2$Count),]

--- a/examples/example_report/index.Rmd
+++ b/examples/example_report/index.Rmd
@@ -179,9 +179,15 @@ Once the Cullen-Frey analysis led us to originally prefer the NB model for its p
 ## Primary distribution selection
 
 ```{r fig.cap="Primary histogram showing the discrete distribution of count data", echo=FALSE}
+
+# set k throughout
+k=8
+
 # library(DBI)
 # data <- NULL
 columns = c("Bsubtilis_168", "Cacetobutylicum_ATCC824", "Cacetobutylicum_DSM1731", "Cacetobutylicum_EA2018", "Cbeijerinckii_NCIMB14988", "Cdifficile_R3", "Cpasteurianum_ATCC6013", "Cpasteurianum_BC1", "Cperfringens_ATCC13124", "Ctetani_E88", "Ecoli_K12MG1655")
+
+## Here is how you could read the same data in from the SQLite3 databases that are kept when --keep-sql is used with profile.
 # i = 1
 # for (f in columns){
 #   con <- dbConnect(RSQLite::SQLite(), paste("../../test/data/", f, ".fasta.8.sqlite3", sep = ""))
@@ -203,7 +209,9 @@ data <- read.csv2("unnormalized_count_matrix.tsv", sep="\t", header=TRUE)
 
 data2 <- gather(data, key="Species", value="Count")
 
-d <- data2[data2$Species == "Bsubtilis_168",]
+data2$id <- rep(1:4^k, length(columns))
+
+#d <- data2[data2$Species == "Bsubtilis_168",]
 
 #summary(kmers$count) # Repetitive
 ggplot(data2) + geom_histogram(aes(x=Count)) + ylab("K-mers") + xlab("Counts") + ggtitle("8-mer  counts across 11 species")
@@ -257,6 +265,26 @@ for (s in columns){
 }
 ggplot(data2) + geom_density(aes(x=Count)) + geom_line(data=d5, aes(y=Fit, x=x, colour=Distr)) + ggtitle("Comparing model fit for 8-mer count across the Clostridia") + xlim(0, 500) + facet_wrap(~Species)
 ```
+
+
+```{r fig.cap="" fig.width=8.41, fig.height=6.5, out.extra='angle=90', echo=FALSE, eval=FALSE}
+
+data2$id <- rep(1:4^k, length(columns))
+d = data2[order(data2$Count),]
+d$species <- as.numeric(as.factor(d$Species))
+
+
+library('vcd')
+ggplot(d, aes(Count)) + geom_histogram()# + facet_wrap(. ~ Species, scales="free_y")
+gf2 <- goodfit(d$Count,type="nbinomial", method = "MinChisq")
+
+plot(gf2)
+library('VGAM')
+
+# Zero truncated NB regression with VGAM
+m1 <- vglm(Count ~ species, family=posnegbinomial(), data=d)
+```
+
 In summary, the k-mer count distribution is best approximated by a negative-binomial model. The k-mer counts/frequencies and their distribution should hold after normalization, and the normalized distributions could be used to model sequence likelihoods via Markov probabilities. Other applications of k-mer probabilities will be explored below.
 
 

--- a/kmerdb/__init__.py
+++ b/kmerdb/__init__.py
@@ -865,7 +865,11 @@ def profile(arguments):
 
         logger.debug("debugging the result of parsefile...")
 
-
+        logger.info("===============================")
+        logger.info("Outer scope")
+        result = db.conn.execute("SELECT * FROM kmers WHERE id = ?", 63).fetchone()
+        logger.info(result)
+        logger.info("===============================")
     metadata=OrderedDict({
         "version": VERSION,
         "metadata_blocks": 1,
@@ -895,8 +899,6 @@ def profile(arguments):
                 print(kmer_dbrecs_per_file)
 
 
-                raise RuntimeError("Still depressing nothing is even here yet")
-                
                 # raise RuntimeError("HOW DOES THIS HAVE NONE")
                 if len(kmer_dbrecs_per_file):
                     i = kmer_dbrecs_per_file[0][0] - 1 # Remove 1 for the Sqlite zero-based indexing
@@ -911,10 +913,12 @@ def profile(arguments):
                         # metadata now has three additional properties, based on the total number of times this k-mer occurred. Eventually the dimension of these new properties should match the count.
                         if arguments.all_metadata:
 
+
                             logger.debug("LAST ASPECT")
-                            seqids = [x[1] for x in kmer_dbrecs_per_file if x[1] is not None]
-                            starts = [x[2] for x in kmer_dbrecs_per_file if x[2] is not None]
-                            reverses = [x[3] for x in kmer_dbrecs_per_file if x[3] is not None]
+
+                            seqids = [x[2] for x in kmer_dbrecs_per_file]
+                            starts = [x[3] for x in kmer_dbrecs_per_file]
+                            reverses = [x[4] for x in kmer_dbrecs_per_file]
                             if "seqids" in kmer_metadata.keys():
                                 kmer_metadata["seqids"] += seqids
                             else:

--- a/kmerdb/database.py
+++ b/kmerdb/database.py
@@ -95,9 +95,9 @@ class SqliteKdb:
         for x in range(self._max_records):
             null_profile.append({
                 'count': 0,
-                'starts': None,
-                'reverses': None,
-                'seqids': None
+                'starts': '[]',
+                'reverses': '[]',
+                'seqids': '[]'
             })
 
         with self._engine.connect() as conn:

--- a/kmerdb/database.py
+++ b/kmerdb/database.py
@@ -24,11 +24,12 @@ logger = logging.getLogger(__file__)
 
 import io
 import os
+import json
 #import sqlite3
 import sys
 import array
 from sqlalchemy import create_engine
-from sqlalchemy import Table, Column, Integer, String, MetaData, ForeignKey, Sequence
+from sqlalchemy import Table, Column, Integer, String, MetaData, ForeignKey, Sequence, Text, Boolean
 from sqlalchemy.pool import NullPool
 #from sqlalchemy.ext.declarative import declarative_base
 #from sqlalchemy.orm import sessionmaker
@@ -77,24 +78,34 @@ class SqliteKdb:
         metadata = MetaData()
         kmers = Table('kmers', metadata,
                       Column('id', Integer, Sequence('kmer_id_seq'), primary_key=True),
-                      Column('count', Integer)
+                      Column('count', Integer),
+                      Column('starts', Text),
+                      Column('reverses', Text),
+                      Column('seqids', Text)
         )
-        reads = Table('reads', metadata,
-                      Column('read_id', String),
-                      Column('kmer_id', None, ForeignKey('kmers.id'))
-        )
+        # reads = Table('reads', metadata,
+        #               Column('read_id', String),
+        #               Column('kmer_id', None, ForeignKey('kmers.id'))
+        # )
         # Create tables
         metadata.create_all(self._engine)
-        null_profile = array.array('B')
+        #null_profile = array.array('B')
+        null_profile = []
         # FIXME This won't work for certain values of k
         for x in range(self._max_records):
-            null_profile.append(0)
+            null_profile.append({
+                'count': 0,
+                'starts': None,
+                'reverses': None,
+                'seqids': None
+            })
+
         with self._engine.connect() as conn:
             while len(null_profile) > 0:
                 temp = []
                 for y in range(rows_per_loading_transaction):
                     if len(null_profile) > 0:
-                        temp.append( {'count': null_profile.pop()} )
+                        temp.append( null_profile.pop(0) )
                 conn.execute(kmers.insert(), temp)
 
             
@@ -117,6 +128,11 @@ class SqliteKdb:
         res = self.conn.execute("SELECT SUM(count) from kmers")
         return res.fetchone()[0]
 
+    def _load_metadata(self):
+        """ Not implemented """
+        return
+
+    
     def __iter__(self):
         return self
 

--- a/kmerdb/kmer.py
+++ b/kmerdb/kmer.py
@@ -15,8 +15,8 @@
 
 '''
 
-
-
+import sys
+from itertools import repeat
 import logging
 logger = logging.getLogger(__file__)
 from Bio import SeqIO, Seq
@@ -68,13 +68,24 @@ class Kmers:
         if not isinstance(seqRecord, Bio.SeqRecord.SeqRecord):
             raise TypeError("kmerdb.kmer.Kmers expects a Bio.SeqRecord.SeqRecord object as its first positional argument")
         kmers = []
+        starts = []
+        reverses = []
         # Each of the n-k+1 string slices become the k-mers
         for c in range(len(seqRecord.seq) - self.k + 1):
             s = seqRecord.seq[c:(c+self.k)]
             kmers.append(str(s))
-            if self.strand_specific: # Reverse complement by default
+            reverses.append(False)
+            starts.append(c)
+            if not self.strand_specific: # Reverse complement by default
                 kmers.append(str(s.reverse_complement()))
-        return {'id': seqRecord.id, 'kmers': list(filter(lambda x: x is not None, map(kmer_to_id, kmers)))}
+                reverses.append(True)
+                starts.append(c)
+        
+        sys.stderr.write("            --- ~~~ --- ~~~  shredded ~~~ --- ~~~ ---\n")
+        sys.stderr.write("a {0}bp long sequence was shredded into L-k+1 {1} total and {1} unique k-mers\n\n".format(len(seqRecord.seq), len(seqRecord.seq)-self.k+1, len(kmers)))
+        output = {'id': seqRecord.id, 'kmers': list(filter(lambda x: x is not None, map(kmer_to_id, kmers))), "seqids": repeat(seqRecord.id, len(starts)), "starts": starts, 'reverses': reverses}
+        #logger.debug(output['seqids'])
+        return output
         #return list(filter(lambda x: x is not None, map(kmer_to_id, kmers)))
 
 

--- a/kmerdb/parse.py
+++ b/kmerdb/parse.py
@@ -19,7 +19,9 @@
 import os
 import sys
 import yaml
-from itertools import chain
+import json
+from itertools import chain, repeat
+
 import tempfile
 
 #import threading
@@ -32,7 +34,7 @@ import logging
 logger = logging.getLogger(__file__)
 
 
-def parsefile(filepath, k, p=1, b=50000, stranded=True):
+def parsefile(filepath:str, k:int, p:int=1, b:int=50000, stranded:bool=True, all_metadata:bool=False):
     """Parse a single sequence file in blocks/chunks with multiprocessing support
 
     :param filepath: Path to a fasta or fastq file
@@ -66,7 +68,10 @@ def parsefile(filepath, k, p=1, b=50000, stranded=True):
     logger.debug("Creating temporary database to tally k-mers: '{0}'".format(temp.name))
     temp.close()
     db = database.SqliteKdb(temp.name, k)
+    from kmerdb import kmer
 
+    data = {} # This is the dictionary of tuples, keyed on k-mer id, and containing 3-tuples ('kmer_id', 'read/start/reverse')
+    keys = set()
     try:
         # Build fasta/fastq parser object to stream reads into memory
         logger.debug("Constructing SeqParser object...")
@@ -87,19 +92,98 @@ def parsefile(filepath, k, p=1, b=50000, stranded=True):
         while len(recs): # While the seqprsr continues to produce blocks of reads
             # Run each read through the shred method
             list_of_dicts = pool.map(Kmer.shred, recs)
+
+            logger.info("Shredding up {0} sequences over {1} parallel cores, like a cheesesteak".format(len(list_of_dicts), p))
+
+
+
+
+            
             # Flatmap to 'kmers', the dictionary of {'id': read_id, 'kmers': [ ... ]}
             kmer_ids = list(chain.from_iterable(map(lambda x: x['kmers'], list_of_dicts)))
-            #read_kmer_relations = list(chain.from_iterable(map(lambda x: list(zip(itertools.repeat(x['id']), x['kmers'])), list_of_dicts)))
+            logger.debug("Flatmapped {0} kmer ids for these {1} sequence ids".format(len(kmer_ids), len(list_of_dicts)))
+            read_kmer_relations = list(chain.from_iterable(map(lambda x: x['seqids'], list_of_dicts)))
+                                       
+            logger.debug("Flatmapped and matched {0} kmers with these {1} sequence ids".format(len(read_kmer_relations), len(list_of_dicts)))
+
+
+            read_kmer_start_offsets = list(chain.from_iterable(map(lambda x: x['starts'], list_of_dicts)))
+            logger.debug("Flatmapped {0} kmers for their {1} offsets".format(len(kmer_ids), len(read_kmer_start_offsets)))
+
+            kmer_reverses = list(chain.from_iterable(map(lambda x: x['reverses'], list_of_dicts)))
+            logger.debug("Flatmapped {0} reverse? bools for these {1} k-mers that were shredded".format(len(kmer_reverses), len(kmer_ids)))
+            if all_metadata is True and len(kmer_ids) == len(read_kmer_relations) and len(read_kmer_relations) == len(read_kmer_start_offsets) and len(read_kmer_start_offsets) == len(kmer_reverses):
+                N = len(read_kmer_start_offsets)
+                for i in range(N):
+                    logger.info("Processing the {0} k-mer by appending read relations, start offsets, and reverse 3-tuples to the metadata column".format(i))                    
+                    if kmer_ids[i] in keys:
+                        
+                        data[kmer_ids[i]].append((kmer_ids[i], read_kmer_relations[i], read_kmer_start_offsets[i], kmer_reverses[i]))
+                    else:
+                        data[kmer_ids[i]] = [(kmer_ids[i], read_kmer_relations[i], read_kmer_start_offsets[i], kmer_reverses[i])]
+
+                    logger.debug("============================")
+                    logger.debug("id")
+                    logger.debug(kmer_ids[i])
+                    logger.debug("============================")
+                    logger.debug("all metadata for this k-mer")
+                    logger.debug(data[kmer_ids[i]])
+                    logger.debug("read_kmer_relations")
+                    logger.debug(read_kmer_relations[i])
+                    logger.debug("start offsets")
+                    logger.debug(read_kmer_start_offsets[i])
+                    logger.debug("reverses")
+                    logger.debug(kmer_reverses[i])
+                        
+                keys = keys.update(set(data.keys()))
+                recs = []
+                logger.warning("Dumping all metadata into the .kdb file eventually")
+                logger.warning("Deferring to dump metadata to SQLite3 later...")
+            elif len(kmer_ids) == len(read_kmer_relations) and len(read_kmer_relations) == len(read_kmer_start_offsets) and len(read_kmer_start_offsets) == len(kmer_reverses) and not all_metadata:
+                pass
+            else:
+                logger.error(len(kmer_ids))
+                logger.error(len(read_kmer_relations))
+                logger.error(len(read_kmer_start_offsets))
+                logger.error(len(kmer_reverses))
+                
+                raise ValueError("Unexpectedly, the number of ids did not match up with the number of other metadata elements per k-mer OR other unknown error")
+            # else:
+            #     raise RuntimeError("Still have no clue what's going on...")
             # On disk k-mer counting
+            # Thank you, this was brilliant
             # https://stackoverflow.com/a/9294062/12855110
+            logger.debug("Parsed/mapped the remainder or the data from list_of_dicts")
+            logger.info("Updating the k-mer counts in the SQLAlchemy connection to SQLite3 for {0} k-mer ids in one transation".format(len(kmer_ids)))
             db.conn.execute("UPDATE kmers SET count = count + 1 WHERE id = ?",
                             list(map(lambda x: (x+1,), kmer_ids)))
-            #db.conn.execute("INSERT INTO reads(read_id, kmer_id) VALUES (?, ?)", read_kmer_relations)
+            
             recs = [r for r in seqprsr] # The next block of exactly 'b' reads
             # This will be logged redundantly with the sys.stderr.write method calls at line 141 and 166 of seqparser.py (in the _next_fasta() and _next_fastq() methods)
             #sys.stderr("\n")
-            #logger.debug("Read {0} more records from the {1} seqparser object".format(len(recs), s))
-            
+            logger.debug("Read {0} more records from the {1} seqparser object".format(len(recs), s))
+        if all_metadata:
+            sys.stderr.write("Writing all metadata keys for each k-mer's relationships to reads into the SQLite3 database...")
+            for kmer_id in data.keys():
+                kmer = data[kmer_id]
+                # Tuple positions assigned from the tuple in the previous for loop
+
+                # Merge previous entry in database
+                reads = db.conn.execute("SELECT seqids FROM kmers WHERE ID = ?", kmer_id)
+                # with tuple positions from the previous loop in the global data hash for this k-mer id
+                reads = [r["seqids"] for r in reads if r["seqids"] is not None] + data[kmer_id]
+
+                print(reads)
+                logger.info("Exiting...")
+                logger.debug("Exiting...")
+                sys.exit(1)
+                
+                # Repeat the same strategy for the following
+                starts = db.conn.execute("SELECT starts FROM kmers WHERE ID = ?", kmer_id)
+                starts = [s["starts"] for s in starts if s["starts"] is not None] + data[kmer_id]
+                reverses = db.conn.execute("SELECT reverses FROM kmers WHERE ID = ?", kmer_id)
+                reverses = [r["reverses"] for r in reverses if r["reverses"] is not None] + data[kmer_id]
+                db.conn.execute("UPDATE kmers SET seqids = ?, starts = ?, reverses = ? WHERE ID = ?", json.dumps(reads), json.dumps(starts), json.dumps(reverses), kmer_id)
         seqprsr.nullomers = db._get_nullomers() # Calculate nullomers at the end
         seqprsr.total_kmers = db._get_sum_counts() # The total number of k-mers processed
     finally:

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ biopython==1.74
 boto3==1.10.8
 botocore==1.13.8
 Cython==0.29.21
-distlib==0.3.0
+distlib==0.3.1
 docutils==0.15.2
 jsonschema==3.1.1
 matplotlib==3.1.3

--- a/setup.py
+++ b/setup.py
@@ -125,7 +125,7 @@ setup(
     ],
     packages=find_packages(exclude=["tests", "*.tests", "*.tests.*", "tests.*"]),
     package_dir={'kmerdb': 'kmerdb'},
-    package_data={'kmerdb': ['examples/example_report/*.Rmd', 'examples/example_report1/*.Rmd'], 'CITATION': ['CITATION']},
+    package_data={'kmerdb': ['CITATION']},
     # If your package is a single module, use this instead of 'packages':
     #py_modules=['kmerdb'],
     #scripts=['bin/kmerdb', 'bin/kmerdb_report.R'],

--- a/test/test_parsefile.py
+++ b/test/test_parsefile.py
@@ -89,6 +89,24 @@ class Test_parsefile(unittest.TestCase):
         with self.assertRaises(TypeError):
             parse.parsefile(self.fasta, self.k, b={'hello': 'world'})
 
+    def test_n_is_int_only(self):
+        """
+        parsefile throws a TypeError if it receives anything but an int
+        """
+        with self.assertRaises(TypeError):
+            parse.parsefile(self.fasta, self.k, n=None)
+        with self.assertRaises(TypeError):
+            parse.parsefile(self.fasta, self.k, n=True)
+        with self.assertRaises(TypeError):
+            parse.parsefile(self.fasta, self.k, n='hello')
+        with self.assertRaises(TypeError):
+            parse.parsefile(self.fasta, self.k, n=1.0)
+        with self.assertRaises(TypeError):
+            parse.parsefile(self.fasta, self.k, n=[1])
+        with self.assertRaises(TypeError):
+            parse.parsefile(self.fasta, self.k, n={'hello': 'world'})
+
+            
     def test_stranded_is_bool_only(self):
         """
         parsefile throws a TypeError if it receives anything but an int
@@ -117,7 +135,7 @@ class Test_parsefile(unittest.TestCase):
                               'mononucleotides': {'A': 1016563, 'C': 418556, 'G': 404380, 'T': 1033834},
                               'nullomers': 0,
                               'sha256': '61b5cf99700219774f05beb9203f0388d95273b227ae7ae37164f1c9a53665ca',
-                              'total_kmers': 5746658,
+                              'total_kmers': 2873329,
                               'total_reads': 2,
                               'unique_kmers': 64}
                              , headerDict)


### PR DESCRIPTION
Now the database can be made much more complicated with the use of the `--all-metadata` option, which fully specifies and records each k-mer's locations in the sequencing dataset, so this can be used to query, but not to index "yet".


A future design could be used to do this, but we should really get the dataset imported into RDF or something like that first, and that comes after the preprint.

The solution to the debugging for this issue was rather obvious, but I set the parameter levels so low, instead of parsing 3.8Mb or whatever the `C. acetobutylicum` genome is for each run, I used 2 7bp test sequences with k set to 3. This led me to issue #35 . But it also just led me to debugging the code much faster and helped me find an off-by-one error that I don't think I would have gotten unless I was using such small values of k. Critical.