### PR TITLE
Hotfix in 'kmerdb view' for IndexError. Closes #65.

### DIFF
--- a/examples/example_report/index.Rmd
+++ b/examples/example_report/index.Rmd
@@ -425,9 +425,23 @@ parallel -j 30 'kmerdb profile -k {2} $(getmetagenome {1})  metagenome_{1}.{2}.k
 
 The list of supporting files can be seen here.
 
+The k-means picture specifies one possible clustering from a set that get explored through time, through different reiterations and refinement to distance metrics and dimensionalit reduction techniqes, to simplify the exploration through space and through rules, often represented as property graphs. I am just beginning to explore a true graph formulation apart from a single significant index. I think it's an interesting project that showcases my ability to design an algorithm from the inside out, and tune a program to desired specifications through software that can do something sophisticated.
+
+Here are a few new images I've been working on that showcase a highlighted view into the data.
+
+Here is a k-means elbow graph, which helps us select the level of dimensionality reduction that is possible while minimizing the rearrangement of data and relationship in a numerical sense. Like a type of normalization. I've been seeking the right data structure to help me specify the normalization. In the file, to have a normalized spectrum but I can't figure out what it is yet...
+
+It's almost like the data structure is stuck inside a weaker machine representation... if I could tease that out with some more statements it would make a world of difference.
+
+
+
+So this is a k-means elbow graph for deciding the primary principal compenents. The same style of visualization is given for t-SNE.
+
 ![The K-means elbow graph for Normalized PCA6](img/kmeans_k4_elbow_graph_on_normalized_pca6.png)}
 
 ![The K-means elbow graph for a t-SNE in $R^{2}$](img/kmeans_k4_elbow_graph_on_tsne2.png)
+
+The spearman distance matrix kmeans elbow graph is given below.
 
 ![The K-means elbow graph for a spearman distance matrix](img/kmeans_k3_elbow_graph_on_spearman_dist.png)
 
@@ -455,6 +469,9 @@ kmerdb matrix Frequency *.8.kdb | kmerdb distance correlation STDIN > Cdiff.Pear
 ![The kmeans (k=3) of a Pearson fidelity distance matrix](img/kmeans_k3_pearson_dist.8.png)
 
 ![The kmeans (k=3) of a Spearman fiedlity distance matrix](img/kmeans_k3_spearman_dist.8.png)
+
+
+
 
 
 # Acknowledgements

--- a/kmerdb/__init__.py
+++ b/kmerdb/__init__.py
@@ -1207,24 +1207,11 @@ def view(arguments):
                 print(yaml.dump(metadata, sort_keys=False))
                 print(config.header_delimiter)
             logger.info("Reading from file...")
+            if kdb_in.dtype != arguments.dtype:
+                raise ValueError("kdb_in.dtype does not match argument dtype")
             try:
-                for line in kdb_in:
-                    print(line)
-                    logger.error("Unexceptable")
-                    raise ValueError("Unexceptable.")
-                    sys.exit(-241)
-                print("foo")
-                line = kdb_in.read_line()
-                kmer_id, count, kmer_metadata = line
-                while kmer_id is not None:
-                    line = kdb_in.read_line()
-                    if line is not None:
-                        kmer_id, count, kmer_metadata = line
-                        print("{0}\t{1}\t{2}".format(kmer_id, count, kmer_metadata))
-                    elif line is None:
-                        kmer_id = None
-                    else:
-                        raise ValueError("First line is unknown type")
+                for i, kmer_id in enumerate(kdb_in.kmer_ids):
+                    print("{0}\t{1}\t{2}".format(kmer_id, kdb_in.profile[i], {}))
 
             except BrokenPipeError as e:
                 logger.error(e)
@@ -1493,6 +1480,7 @@ def cli():
     view_parser = subparsers.add_parser("view", help="View the contents of the .kdb file")
     view_parser.add_argument("-v", "--verbose", help="Prints warnings to the console by default", default=0, action="count")
     view_parser.add_argument("-H", "--header", action="store_true", help="Include header in the output")
+    view_parser.add_argument("--dtype", type=str, default="uint64", help="Read in the profiles as unsigned integer 64bit NumPy arrays")
     view_parser.add_argument("-d", "--decompress", action="store_true", help="Decompress input? DEFAULT: ")
     view_parser.add_argument("-c", "--compress", action="store_true", help="Print compressed output")
     view_parser.add_argument("kdb_in", type=str, nargs="?", default=None, help="A k-mer database file (.kdb) to be read (Optional)")


### PR DESCRIPTION
Dummy printer still being used in `__init__.py`. Mostly just trying to read in data into the right types of arrays.