### PR TITLE
True parallelization for kmerdb distance pearson

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ NOTE: This project is in alpha stage. Development is ongoing. But feel free to c
 
 ## Development Status
 
-
+[![Downloads](https://pepy.tech/badge/kmerdb)](https://pypi.org/project/kmerdb)
 ![PyPI - Downloads](https://img.shields.io/pypi/dm/kmerdb)
 [![GitHub Downloads](https://img.shields.io/github/downloads/MatthewRalston/kdb/total.svg?style=social&logo=github&label=Download)](https://github.com/MatthewRalston/kmerdb/releases)
 [![PyPI version](https://img.shields.io/pypi/v/kmerdb.svg)][pip]

--- a/kmerdb/config.py
+++ b/kmerdb/config.py
@@ -17,7 +17,7 @@
 
 
 
-VERSION="0.6.9"
+VERSION="0.7.0"
 header_delimiter = "\n" + ("="*24) + "\n"
 
 metadata_schema = {

--- a/kmerdb/distance.pyx
+++ b/kmerdb/distance.pyx
@@ -23,11 +23,17 @@ logger = logging.getLogger(__file__)
 
 import math
 import numpy as np
+import multiprocessing as mp
 cimport numpy as cnp
 cimport cython
 import sys
 #from numba import jit
 #import functools
+
+
+def pearson_correlation(a, b, total_kmers, sharedr):
+    r = correlation(a, b, total_kmers)
+    sharedr.value = r
 
 #cpdef double correlation(cnp.uint64_t[:] a, cnp.uint64_t[:] b, int total_kmers):
 cpdef double correlation(long[:] a, long[:] b, int total_kmers):
@@ -69,9 +75,10 @@ cpdef double correlation(long[:] a, long[:] b, int total_kmers):
             elif ssxy == 0:
                 logger.info("Sum of squared residuals is 0")
             elif ssxy > 0:
-                logger.info("Looping...")
+                logger.info("Calculating next ssxy...")
                 continue
     logger.info("Custom Pearson correlation acquired")
     logger.info("{0}/sqrt({1}*{2})".format(ssxy, ssxx, ssyy))
-    return ssxy/(np.sqrt(ssxx*ssyy))
+    r = ssxy/(np.sqrt(ssxx*ssyy))
+    return r
     

--- a/setup.py
+++ b/setup.py
@@ -93,11 +93,11 @@ NAME = 'kmerdb'
 DESCRIPTION = 'Yet another kmer library for Python'
 long_description = 'See README.md for details'
 URL = 'https://github.com/MatthewRalston/kmerdb'
-CURRENT_RELEASE = "https://github.com/MatthewRalston/kmerdb/archive/v0.0.4.tar.gz"
+CURRENT_RELEASE = "https://github.com/MatthewRalston/kmerdb/archive/v0.7.0.tar.gz"
 EMAIL = 'mrals89@gmail.com'
 AUTHOR = 'Matthew Ralston'
 REQUIRES_PYTHON = '>=3.6.0'
-VERSION = "0.6.9"
+VERSION = "0.7.0"
 # What packages are required for this module to be executed?
 
 REQUIRED = [l.rstrip() for l in open('./requirements.txt', 'r')]


### PR DESCRIPTION
Closes #91. Adds true parallelization to the 'pearson' correlation distance metric in the 'kmerdb distance' sub-command. Leaves faux-parallelization (.kdb file reading) as a supported feature for other metrics.

The pearson distance uses a custom Cython function to calculate the correlation coefficient known as Pearson's r. The number ranges from -1 -to- 1 and provides the real correlation information most are concerned with (as opposed to the coefficient of determination R^2).

Moreover, this commit parallelizes the execution of this function (which isn't simply `map`able using the multiprocessing module) to populate a lower-diagonal matrix of ~ $n^{2}/2$ elements (it's actually $(1+n)n/2$). This should make for much faster generation of pearson distance matrices for users who have already gone through the painstaking process of letting me count the k-mers in my format, and generating all of those files in parallel as the user sees fit.

Pearson's r and Spearman correlation coefficients are the most commonly used metrics for calculation of correlation distance matrices. Both are useful in eyeballing how similar two organisms, replicates are two one another.

Fidelity of the profile upon generation of artificial sequencing depth, selection, bias (but not error, yet) and other factors continues to be an important topic under investigation. I've found that I'm not always satisfied by the correlations returned by scipy's 'correlation' distance, nor the 'spearman', and so during investigation of the formulation of various 'correlation coefficients', I finally settled upon implementing Pearson's r in Cython.