### PR TITLE
v0.7.5 - fixes minor regressions, --sorted truthiness, ignored --quiet in conditional branch, and fixes duplicate col2 among others

### DIFF
--- a/kmerdb/__init__.py
+++ b/kmerdb/__init__.py
@@ -1211,7 +1211,7 @@ def profile(arguments):
         all_metadata = []
         if arguments.all_metadata:
 
-            if arguments.sorted:
+            if arguments.sorted is True:
                 j = 0
                 list_of_duples = list(zip(kmer_ids, counts))
                 logger.debug(list_of_duples[0:3])
@@ -1237,8 +1237,9 @@ def profile(arguments):
                     assert j <= i + 1, "profile | row index was not sequential. Possibly read improperly."
                     assert idx == kmer_ids[i], "profile | row index did not match a kmer_id"
                     logger.info("First is the implicit row index, next is a k-mer id, next is the corresponding k-mer id to the row-index (may not match from sorting), next is the count and frequencies")
-                    print("{0}\t{1}\t{2}\t{3}\t{4}".format(i, idx, kmer_ids[i], counts[idx], frequencies[idx]))
-                    kdb_out.write("{0}\t{1}\t{2}\t{3}\t{4}\t{5}\n".format(i, idx, kmer_ids[i], counts[idx], frequencies[idx], json.dumps(kmer_metadata)))
+                    if arguments.quiet is not True:
+                        print("{0}\t{1}\t{2}\t{3}".format(i, kmer_ids[idx], counts[idx], frequencies[idx]))
+                    kdb_out.write("{0}\t{1}\t{2}\t{3}\t{4}\n".format(i, kmer_ids[idx], counts[idx], frequencies[idx], json.dumps(kmer_metadata)))
                     j += 1
             else:
                 j = 0
@@ -1253,8 +1254,8 @@ def profile(arguments):
                     frequencies[idx] = frequencies[idx]
                     logger.info("First is the implicit row index, next is a k-mer id, next is the corresponding k-mer id to the row-index (may not match from sorting), next is the count and frequencies")
                     if arguments.quiet is not True:
-                        print("{0}\t{1}\t{2}\t{3}\t{4}".format(i, idx, kmer_ids[i], counts[idx], frequencies[idx]))
-                    kdb_out.write("{0}\t{1}\t{2}\t{3}\t{4}\t{5}\n".format(i, idx, kmer_ids[i], counts[i], frequencies[i], json.dumps(kmer_metadata)))
+                        print("{0}\t{1}\t{2}\t{3}".format(i, kmer_ids[idx], counts[idx], frequencies[idx]))
+                    kdb_out.write("{0}\t{1}\t{2}\t{3}\t{4}\n".format(i, kmer_ids[idx], counts[i], frequencies[i], json.dumps(kmer_metadata)))
                     j += 1
         else:
             if arguments.sorted:

--- a/kmerdb/__init__.py
+++ b/kmerdb/__init__.py
@@ -1255,7 +1255,7 @@ def profile(arguments):
                     logger.info("First is the implicit row index, next is a k-mer id, next is the corresponding k-mer id to the row-index (may not match from sorting), next is the count and frequencies")
                     if arguments.quiet is not True:
                         print("{0}\t{1}\t{2}\t{3}".format(i, kmer_ids[idx], counts[idx], frequencies[idx]))
-                    kdb_out.write("{0}\t{1}\t{2}\t{3}\t{4}\n".format(i, kmer_ids[idx], counts[i], frequencies[i], json.dumps(kmer_metadata)))
+                    kdb_out.write("{0}\t{1}\t{2}\t{3}\t{4}\n".format(i, kmer_ids[idx], counts[idx], frequencies[idx], json.dumps(kmer_metadata)))
                     j += 1
         else:
             if arguments.sorted:
@@ -1266,19 +1266,19 @@ def profile(arguments):
                 for i, idx in enumerate(reverse_kmer_ids_sorted_by_count):
 
                     kmer_id = int(kmer_ids[idx])
-                    logger.info("{0}\t{1}\t{2}\t{3}\t{4}".format(i, idx, kmer_ids[i], counts[idx], frequencies[idx]))
+                    logger.info("{0}\t{1}\t{2}\t{3}".format(i, kmer_ids[idx], counts[idx], frequencies[idx]))
                     seq = kmer.id_to_kmer(kmer_id, arguments.k)
                     kmer_metadata = kmer.neighbors(seq, arguments.k)
                     all_metadata.append(kmer_metadata)
                     counts[idx] = counts[idx]
                     frequencies[idx] = frequencies[idx]
                     if arguments.quiet is not True:
-                        print("{0}\t{1}\t{2}\t{3}\t{4}".format(i, idx, kmer_ids[idx], counts[idx], frequencies[idx]))
-                    kdb_out.write("{0}\t{1}\t{2}\t{3}\t{4}\t{5}\n".format(i, idx, kmer_ids[i], counts[idx], frequencies[idx], json.dumps(kmer_metadata)))
+                        print("{0}\t{1}\t{2}\t{3}".format(i, kmer_ids[idx], counts[idx], frequencies[idx]))
+                    kdb_out.write("{0}\t{1}\t{2}\t{3}\t{4}\n".format(i, kmer_ids[idx], counts[idx], frequencies[idx], json.dumps(kmer_metadata)))
             else:
                 for i, idx in enumerate(kmer_ids):
                     kmer_id = int(idx)
-                    logger.info("{0}\t{1}\t{2}\t{3}\t{4}".format(i, idx, kmer_ids[i], counts[idx], frequencies[idx]))
+                    logger.info("{0}\t{1}\t{2}\t{3}".format(i, kmer_ids[idx], counts[idx], frequencies[idx]))
                     p = profile[i]
                     c = counts[i]
                     f = frequencies[i]
@@ -1286,8 +1286,8 @@ def profile(arguments):
                     kmer_metadata = kmer.neighbors(seq, arguments.k) # metadata is initialized by the neighbors
                     all_metadata.append(kmer_metadata)
                     if arguments.quiet is not True:
-                        print("{0}\t{1}\t{2}\t{3}\t{4}".format(i, idx, kmer_ids[i], counts[i], frequencies[i]))
-                    kdb_out.write("{0}\t{1}\t{2}\t{3}\t{4}\t{5}\n".format(i, idx, kmer_ids[i], counts[i], frequencies[i], json.dumps(kmer_metadata)))
+                        print("{0}\t{1}\t{2}\t{3}".format(i, kmer_ids[idx], counts[idx], frequencies[idx]))
+                    kdb_out.write("{0}\t{1}\t{2}\t{3}\t{4}\n".format(i, kmer_ids[idx], counts[idx], frequencies[idx], json.dumps(kmer_metadata)))
         logger.info("Wrote 4^k = {0} k-mer counts + neighbors to the .kdb file.".format(total_kmers))
 
         logger.info("Done")

--- a/kmerdb/config.py
+++ b/kmerdb/config.py
@@ -17,7 +17,7 @@
 
 
 
-VERSION="0.7.4"
+VERSION="0.7.5"
 header_delimiter = "\n" + ("="*24) + "\n"
 
 metadata_schema = {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kmerdb"
-version = "0.7.4"
+version = "0.7.5"
 description = "Yet another kmer library for Python"
 readme = "README.md"
 authors = [{name="Matt Ralston <mralston.development@gmail.com>", email="mralston.development@gmail.com"}]
@@ -82,13 +82,13 @@ dependencies = [
 	     #'numpy>=1.21.6',
 	     #'pandas>=1.3.5',
 	     #'scipy>=1.7.3',
-	     #'sklearn>=0.0',
+	     #'sklearn>=0.0.post1',
 
 	     #'numpy>=1.24.1',
 	     'numpy>=1.22.0',
 	     'pandas>=1.3.5',
 	     'scipy>=1.9.3',
-	     'sklearn>=0.0.post1',
+	     'scikit-learn>=1.4.0',
 
 	     #######################
 	     # Statistical language

--- a/setup.py
+++ b/setup.py
@@ -113,7 +113,7 @@ CURRENT_RELEASE = "https://github.com/MatthewRalston/kmerdb/archive/v0.7.0.tar.g
 EMAIL = 'mrals89@gmail.com'
 AUTHOR = 'Matthew Ralston'
 REQUIRES_PYTHON = '>=3.8.0'
-VERSION = "0.7.4"
+VERSION = "0.7.5"
 KEYWORDS = ["bioinformatics", "fastq", "fasta", "k-mer", "kmer", "k-merdb", "kmerdb", "kdb"],
 CLASSIFIERS = [
     "Development Status :: 1 - Planning",


### PR DESCRIPTION
Fixes some minor regressions, and a major regression involving tabular format specification.

Specifically, col1 is a row number. Plain.

Col2 and col3 are malformed, now is just a k-mer id. Col 3 becomes the count, col4 is frequency, no col5.